### PR TITLE
Fix brew cask install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Works on macOS, Linux and Windows.
 
 ```shell
 brew tap epk/epk
+
+# Homebrew < 2.6.0
 brew cask install font-sf-mono-nerd-font
+
+# Homebrew >= 2.6.0
+brew install --cask font-sf-mono-nerd-font
 ```
 
 For personal use only.


### PR DESCRIPTION
Homebrew 2.6.0 dropped old syntax for working with casks, so this command doesn't work in newer homebrew setup.